### PR TITLE
build: add CI, cover the mail handling, and replace Dependabot with Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "07:00"
-  open-pull-requests-limit: 99

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # maven-compiler-plugin in pom.xml is configured with source/target 1.8. Keep this
+      # java-version and that configuration in step; renovate.json groups them so they
+      # are always proposed together.
+      - name: Set up Java 8
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: "8"
+          cache: maven
+      - name: Verify
+        run: mvn -B verify
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage
+          if-no-files-found: ignore
+          path: target/site/jacoco

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 /junkEmailMover.iml
 /target/
 /.idea/
+
+# log4j2.xml writes to a relative "logs" directory whenever the application is
+# started from the repository root. The build itself runs from target/.
+/logs/
+
+# maven-shade-plugin is configured not to write this, but a plain `mvn shade:shade`
+# still would.
+/dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,9 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- All Log4j artifacts must be released and upgraded together, see the
+             comment on the dependencies below. -->
+        <log4j.version>2.26.1</log4j.version>
     </properties>
 
     <build>
@@ -52,19 +55,22 @@
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
-            <version>[1.6.0,]</version>
+            <version>1.6.2</version>
         </dependency>
 
-        <!-- Log4j -->
+        <!-- Log4j. log4j-core requires the exact same version of log4j-api, so the
+             two share a single property and are upgraded in lockstep.
+             Log4j 3.x requires Java 17 and is therefore out of reach while this
+             project targets Java 8. -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>[2.8.2,]</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>[2.8.2,]</version>
+            <version>${log4j.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <!-- Same literal as java-version in .github/workflows/ci.yml, which is
+                         what lets renovate.json track and move the two together. -->
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,62 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.5</version>
+                <configuration>
+                    <!-- log4j2.xml writes its appenders to a relative "logs" directory.
+                         Run the tests from target/ so that the build never litters the
+                         working tree. -->
+                    <workingDirectory>${project.build.directory}</workingDirectory>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.15</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <!-- Bound to verify, which is what CI runs, so the gate cannot be
+                         bypassed by the normal build command. -->
+                    <execution>
+                        <id>check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- Package all the dependencies into the JAR -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -38,6 +94,9 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <!-- Keep the build from writing dependency-reduced-pom.xml
+                                 into the working tree. -->
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>martinfrancois.EmailHandler</mainClass>
@@ -83,6 +142,25 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>33.4.5-jre</version>
+        </dependency>
+
+        <!-- Real in-process IMAP and SMTP servers, so the tests drive the actual
+             JavaMail protocol implementation instead of a mock of it.
+             GreenMail 1.6.x is the last line that speaks the javax.mail namespace;
+             2.x requires jakarta.mail 2 and Java 11.
+             Its own JavaMail copy is excluded so the tests run against exactly the
+             com.sun.mail:javax.mail version this project ships. -->
+        <dependency>
+            <groupId>com.icegreen</groupId>
+            <artifactId>greenmail</artifactId>
+            <version>1.6.15</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>jakarta.mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/renovate.json
+++ b/renovate.json
@@ -61,6 +61,24 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "addLabels": ["major update"]
+    },
+    {
+      "description": "Lockstep: log4j-core declares its log4j-api dependency with no version of its own and inherits it from log4j-bom, which pins log4j-api to log4j-core's own version (log4j-bom 2.26.1 manages log4j-api at exactly 2.26.1). A build with mismatched Log4j artifacts is unsupported. Non-major updates are already atomic because both artifacts read the same ${log4j.version} property in pom.xml; this rule extends that to majors, which the rule above would otherwise let land one artifact at a time.",
+      "matchDatasources": ["maven"],
+      "matchPackageNames": [
+        "org.apache.logging.log4j:log4j-api",
+        "org.apache.logging.log4j:log4j-core"
+      ],
+      "matchUpdateTypes": ["major"],
+      "groupName": "log4j"
+    },
+    {
+      "description": "Lockstep: the JDK the CI job installs and the language level maven-compiler-plugin targets are the same number written in two files. If the pom asks for a release newer than the installed JDK, javac refuses to compile; if it asks for an older one, CI publishes bytecode for a runtime it never ran a test on. Both references are named java, so this one rule moves all three occurrences in a single branch. Raising the language level also raises the minimum JRE for the shaded jar this project publishes, which is a maintainer's decision, so dependencyDashboardApproval holds the move until a human ticks the box rather than opening the pull request unprompted.",
+      "matchDepNames": ["java"],
+      "groupName": "java toolchain",
+      "extractVersion": "^(?<version>\\d+)",
+      "versioning": "docker",
+      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,29 @@
     "enabled": true,
     "labels": ["security"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "The JDK the CI job installs. No built-in manager reads the java-version input of actions/setup-java.",
+      "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      "matchStrings": ["java-version:\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "java",
+      "datasourceTemplate": "java-version",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "The language level maven-compiler-plugin targets. The maven manager reads plugin versions but not plugin configuration.",
+      "managerFilePatterns": ["/(^|/)pom\\.xml$/"],
+      "matchStrings": [
+        "<source>(?<currentValue>[^<]+)</source>",
+        "<target>(?<currentValue>[^<]+)</target>"
+      ],
+      "depNameTemplate": "java",
+      "datasourceTemplate": "java-version",
+      "versioningTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "description": "Bundle every non-major update into one automergeable pull request. Majors are deliberately excluded so a pending major never blocks the automergeable bundle.",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":rebaseStalePrs"
+  ],
+  "reviewers": ["martinfrancois"],
+  "labels": ["dependencies"],
+  "rangeStrategy": "replace",
+  "pinDigests": true,
+  "prConcurrentLimit": 0,
+  "branchConcurrentLimit": 0,
+  "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "internalChecksFilter": "strict",
+  "statusCheckWhen": {
+    "minimumReleaseAge": "never"
+  },
+  "dependencyDashboardApproval": false,
+  "separateMajorMinor": true,
+  "separateMultipleMajor": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "packageRules": [
+    {
+      "description": "Bundle every non-major update into one automergeable pull request. Majors are deliberately excluded so a pending major never blocks the automergeable bundle.",
+      "matchUpdateTypes": ["minor", "patch", "pin", "pinDigest", "digest"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-non-major",
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "Major updates land one at a time and are merged by a human after review of the migration notes. This rule deliberately does not set groupName: majors are already ungrouped because the bundle above matches non-major types only, and forcing groupName here would split lockstep groups whose members must move together across a major boundary.",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["major update"]
+    }
+  ]
+}

--- a/src/main/java/martinfrancois/EmailHandler.java
+++ b/src/main/java/martinfrancois/EmailHandler.java
@@ -1,5 +1,6 @@
 package martinfrancois;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.sun.mail.imap.IMAPFolder;
 import java.util.Date;
@@ -89,7 +90,8 @@ public class EmailHandler {
 
   }
 
-  private static void moveSpam(Settings settings) {
+  @VisibleForTesting
+  static void moveSpam(Settings settings) {
     LOGGER.info("Trying to connect to host: " + settings.imap.host + " with user: " + settings.imap.username);
     try {
       connect(settings.imap, settings.smtp);
@@ -112,7 +114,8 @@ public class EmailHandler {
     }
   }
 
-  private static IMAPFolder getFolder(Store store, String folderName) throws MessagingException {
+  @VisibleForTesting
+  static IMAPFolder getFolder(Store store, String folderName) throws MessagingException {
     IMAPFolder folder = (IMAPFolder) store.getFolder(folderName);
     if (!folder.isOpen()) {
       folder.open(Folder.READ_WRITE);
@@ -120,7 +123,8 @@ public class EmailHandler {
     return folder;
   }
 
-  private static void connect(Connection imap, Connection smtp) throws MessagingException {
+  @VisibleForTesting
+  static void connect(Connection imap, Connection smtp) throws MessagingException {
     // connect IMAP
     imap.prop = new Properties();
     imap.session = Session.getInstance(imap.prop);
@@ -141,7 +145,8 @@ public class EmailHandler {
     }
   }
 
-  private static void printFolderList(Store store) throws MessagingException {
+  @VisibleForTesting
+  static void printFolderList(Store store) throws MessagingException {
     System.out.println(store);
 
     Folder[] f = store.getDefaultFolder().list();
@@ -155,7 +160,8 @@ public class EmailHandler {
    * Messages needs to belong to the "from" folder. If it is null, all messages will be used.
    * Returns true if successful, false if unsuccessful.
    */
-  private static boolean moveMessages(Folder from, Folder to, Message[] messages, Settings settings) throws MessagingException {
+  @VisibleForTesting
+  static boolean moveMessages(Folder from, Folder to, Message[] messages, Settings settings) throws MessagingException {
     // get a list of javamail messages as an array of messages
     if (messages == null) {
       LOGGER.trace("messages is null, copying all messages");
@@ -185,7 +191,8 @@ public class EmailHandler {
    * Messages needs to belong to the "from" folder. If it is null, all messages will be used.
    * Returns true if successful, false if unsuccessful.
    */
-  private static boolean copyMessages(Folder from, Folder to, Message[] messages) throws MessagingException {
+  @VisibleForTesting
+  static boolean copyMessages(Folder from, Folder to, Message[] messages) throws MessagingException {
     // get counts before the operations
     int fromCount = from.getMessageCount();
     int toCount = to.getMessageCount();
@@ -208,7 +215,8 @@ public class EmailHandler {
     return false;
   }
 
-  private static boolean checkAmount(Folder folder, int expected) throws MessagingException {
+  @VisibleForTesting
+  static boolean checkAmount(Folder folder, int expected) throws MessagingException {
     int threshold = 20;
     int attempt = 0;
     int actual = -1;
@@ -231,7 +239,8 @@ public class EmailHandler {
    * @return true if successful
    * @throws MessagingException
    */
-  private static boolean deleteMessages(Folder folder, Message[] messages) throws MessagingException {
+  @VisibleForTesting
+  static boolean deleteMessages(Folder folder, Message[] messages) throws MessagingException {
     LOGGER.trace("Deleting messages...");
 
     int folderCount = folder.getMessageCount();
@@ -254,7 +263,8 @@ public class EmailHandler {
     return false;
   }
 
-  private static boolean forwardMessage(Message message, Settings settings) {
+  @VisibleForTesting
+  static boolean forwardMessage(Message message, Settings settings) {
     LOGGER.trace("Forwarding Messages...");
     try {
       // Get all the information from the message
@@ -295,7 +305,8 @@ public class EmailHandler {
     return true;
   }
 
-  private static class Connection {
+  @VisibleForTesting
+  static class Connection {
     String host;
     String username;
     String password;
@@ -310,7 +321,8 @@ public class EmailHandler {
     }
   }
 
-  private static class Settings {
+  @VisibleForTesting
+  static class Settings {
     private static final String SUBJECT_PREFIX = "[SPAM] ";
     Connection imap;
     Connection smtp;

--- a/src/main/java/martinfrancois/SecurePreferences.java
+++ b/src/main/java/martinfrancois/SecurePreferences.java
@@ -18,7 +18,6 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import sun.misc.BASE64Encoder;
 
 /**
  * Created by François Martin on 11.09.2017.
@@ -109,7 +108,11 @@ public class SecurePreferences {
       byte[] byteCipherText = new byte[0];
       byteCipherText = aesCipherForEncryption
           .doFinal(byteDataToEncrypt);
-      encrypted = new BASE64Encoder().encode(byteCipherText);
+      // Must stay symmetric with the java.util.Base64 decoder used in decrypt():
+      // sun.misc.BASE64Encoder wrapped its output every 76 characters, which
+      // Base64.getDecoder() rejects, so any value long enough to wrap could be
+      // stored but never read back again.
+      encrypted = Base64.getEncoder().encodeToString(byteCipherText);
     } catch (IllegalBlockSizeException | BadPaddingException | InvalidKeyException | NoSuchPaddingException | InvalidAlgorithmParameterException | NoSuchAlgorithmException e) {
       LOGGER.error("Error during encryption: " + e.toString());
       LOGGER_EXCEPTION.debug(Throwables.getStackTraceAsString(e));

--- a/src/test/java/martinfrancois/EmailHandlerMailboxTest.java
+++ b/src/test/java/martinfrancois/EmailHandlerMailboxTest.java
@@ -1,0 +1,301 @@
+package martinfrancois;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetup;
+import com.sun.mail.imap.IMAPFolder;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+import javax.mail.Folder;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.Store;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Runs the mailbox handling against real IMAP and SMTP servers.
+ *
+ * <p>GreenMail speaks the actual protocols over a socket, so every assertion here goes through
+ * the {@code com.sun.mail} implementation: folder open, APPEND, COPY, the DELETED flag, EXPUNGE,
+ * MIME multipart assembly and SMTP delivery. Mocking JavaMail would make these tests pass no
+ * matter which version of JavaMail is on the classpath, which is exactly what they are meant to
+ * detect.
+ */
+public class EmailHandlerMailboxTest {
+
+  private static final String BIND_ADDRESS = "127.0.0.1";
+  private static final String PASSWORD = "secret";
+  // EmailHandler authenticates SMTP with the account's own address, so the GreenMail
+  // login has to be the address rather than a separate user name.
+  private static final String MAILBOX = "junk@localhost";
+  private static final String RECIPIENT = "postmaster@localhost";
+  private static final String JUNK = "Junk";
+  private static final String INBOX = "Inbox";
+
+  private GreenMail greenMail;
+  private Store store;
+  private Properties smtpProperties;
+  private Session smtpSession;
+
+  @Before
+  public void startMailServers() throws Exception {
+    greenMail = new GreenMail(new ServerSetup[] {
+        new ServerSetup(0, BIND_ADDRESS, ServerSetup.PROTOCOL_IMAP),
+        new ServerSetup(0, BIND_ADDRESS, ServerSetup.PROTOCOL_SMTP)});
+    greenMail.start();
+    greenMail.setUser(MAILBOX, PASSWORD);
+    greenMail.setUser(RECIPIENT, PASSWORD);
+
+    int imapPort = greenMail.getImap().getPort();
+    assertTrue("GreenMail did not pick a dynamic IMAP port", imapPort > 0);
+    Properties imapProperties = new Properties();
+    imapProperties.setProperty("mail.imap.host", BIND_ADDRESS);
+    imapProperties.setProperty("mail.imap.port", Integer.toString(imapPort));
+    store = Session.getInstance(imapProperties).getStore("imap");
+    store.connect(BIND_ADDRESS, imapPort, MAILBOX, PASSWORD);
+
+    // Same properties EmailHandler.connect() builds for SMTP, plus the port GreenMail
+    // happened to pick and a relaxed trust setting for its self signed STARTTLS certificate.
+    smtpProperties = new Properties();
+    smtpProperties.put("mail.smtp.starttls.enable", "true");
+    smtpProperties.put("mail.smtp.ssl.trust", "*");
+    smtpProperties.put("mail.smtp.host", BIND_ADDRESS);
+    smtpProperties.put("mail.smtp.port", Integer.toString(greenMail.getSmtp().getPort()));
+    smtpSession = Session.getInstance(smtpProperties);
+
+    Folder junk = store.getFolder(JUNK);
+    if (!junk.exists()) {
+      assertTrue("could not create the Junk folder", junk.create(Folder.HOLDS_MESSAGES));
+    }
+  }
+
+  @After
+  public void stopMailServers() {
+    try {
+      if (store != null && store.isConnected()) {
+        store.close();
+      }
+    } catch (MessagingException ignored) {
+      // the servers are going away anyway
+    }
+    if (greenMail != null) {
+      greenMail.stop();
+    }
+  }
+
+  private EmailHandler.Settings settings(String recipient) {
+    EmailHandler.Connection imap = new EmailHandler.Connection(BIND_ADDRESS, MAILBOX, PASSWORD);
+    imap.store = store;
+    EmailHandler.Connection smtp = new EmailHandler.Connection(BIND_ADDRESS, MAILBOX, PASSWORD);
+    smtp.prop = smtpProperties;
+    smtp.session = smtpSession;
+    return new EmailHandler.Settings(imap, smtp, recipient);
+  }
+
+  private void fillJunk(int count) throws MessagingException {
+    Folder junk = store.getFolder(JUNK);
+    junk.open(Folder.READ_WRITE);
+    try {
+      Message[] messages = new Message[count];
+      for (int i = 0; i < count; i++) {
+        MimeMessage message = new MimeMessage(smtpSession);
+        message.setFrom(new InternetAddress("spammer" + i + "@example.com"));
+        message.setRecipient(Message.RecipientType.TO, new InternetAddress(MAILBOX));
+        message.setSubject("Cheap pills " + i);
+        message.setSentDate(new Date());
+        message.setText("unsolicited body " + i);
+        message.saveChanges();
+        messages[i] = message;
+      }
+      junk.appendMessages(messages);
+    } finally {
+      junk.close(false);
+    }
+  }
+
+  private static List<String> subjectsOf(Folder folder) throws MessagingException {
+    List<String> subjects = new ArrayList<String>();
+    for (Message message : folder.getMessages()) {
+      subjects.add(message.getSubject());
+    }
+    return subjects;
+  }
+
+  private List<MimeMessage> forwardedMessages() throws MessagingException {
+    List<MimeMessage> forwarded = new ArrayList<MimeMessage>();
+    for (MimeMessage message : greenMail.getReceivedMessages()) {
+      if (message.getSubject() != null && message.getSubject().startsWith("[SPAM] ")) {
+        forwarded.add(message);
+      }
+    }
+    return forwarded;
+  }
+
+  @Test
+  public void opensAnExistingFolderReadWrite() throws Exception {
+    IMAPFolder junk = EmailHandler.getFolder(store, JUNK);
+
+    assertNotNull(junk);
+    assertTrue(junk.isOpen());
+    assertEquals(Folder.READ_WRITE, junk.getMode());
+  }
+
+  @Test
+  public void movesEveryJunkMessageIntoTheInbox() throws Exception {
+    fillJunk(3);
+    IMAPFolder junk = EmailHandler.getFolder(store, JUNK);
+    IMAPFolder inbox = EmailHandler.getFolder(store, INBOX);
+    int inboxBefore = inbox.getMessageCount();
+
+    assertTrue(EmailHandler.moveMessages(junk, inbox, null, settings("")));
+
+    assertEquals(0, junk.getMessageCount());
+    assertEquals(inboxBefore + 3, inbox.getMessageCount());
+    List<String> delivered = subjectsOf(inbox);
+    assertTrue(delivered.toString(), delivered.contains("Cheap pills 0"));
+    assertTrue(delivered.toString(), delivered.contains("Cheap pills 2"));
+  }
+
+  @Test
+  public void movesOnlyTheMessagesItWasGiven() throws Exception {
+    fillJunk(3);
+    IMAPFolder junk = EmailHandler.getFolder(store, JUNK);
+    IMAPFolder inbox = EmailHandler.getFolder(store, INBOX);
+    Message[] onlyTheFirst = {junk.getMessages()[0]};
+
+    assertTrue(EmailHandler.moveMessages(junk, inbox, onlyTheFirst, settings("")));
+
+    assertEquals(2, junk.getMessageCount());
+    assertEquals(1, inbox.getMessageCount());
+    assertEquals("Cheap pills 0", inbox.getMessages()[0].getSubject());
+    assertFalse(subjectsOf(junk).contains("Cheap pills 0"));
+  }
+
+  @Test
+  public void forwardsEveryMovedMessageToTheRecipient() throws Exception {
+    fillJunk(2);
+    IMAPFolder junk = EmailHandler.getFolder(store, JUNK);
+    IMAPFolder inbox = EmailHandler.getFolder(store, INBOX);
+
+    assertTrue(EmailHandler.moveMessages(junk, inbox, null, settings(RECIPIENT)));
+
+    List<MimeMessage> forwarded = forwardedMessages();
+    assertEquals(forwarded.toString(), 2, forwarded.size());
+    MimeMessage first = forwarded.get(0);
+    assertEquals(MAILBOX, first.getFrom()[0].toString());
+    assertEquals(RECIPIENT, first.getRecipients(Message.RecipientType.TO)[0].toString());
+    assertTrue(first.getSubject(), first.getSubject().startsWith("[SPAM] Cheap pills "));
+    // The original body is carried over as a MIME body part, not dropped.
+    assertTrue(GreenMailUtil.getBody(first).contains("unsolicited body"));
+    // Forwarding does not stop the move: the junk folder is still emptied.
+    assertEquals(0, junk.getMessageCount());
+  }
+
+  @Test
+  public void reportsAFailureWhenTheRecipientAddressIsUnusable() throws Exception {
+    fillJunk(1);
+    IMAPFolder junk = EmailHandler.getFolder(store, JUNK);
+    Message message = junk.getMessages()[0];
+    LogFile stackTraces = LogFile.mark(LogFile.STACK_TRACES);
+
+    assertFalse(EmailHandler.forwardMessage(message, settings("this is not an address")));
+
+    String trace = stackTraces.appended();
+    assertTrue(trace, trace.contains("javax.mail.internet.AddressException"));
+  }
+
+  @Test
+  public void keepsTheJunkMessagesWhenForwardingFails() throws Exception {
+    fillJunk(2);
+    IMAPFolder junk = EmailHandler.getFolder(store, JUNK);
+    IMAPFolder inbox = EmailHandler.getFolder(store, INBOX);
+
+    assertFalse(EmailHandler.moveMessages(junk, inbox, null, settings("not an address")));
+
+    // The safety property this program lives or dies by: nothing is deleted from the source
+    // folder unless every earlier step reported success.
+    assertEquals(2, junk.getMessageCount());
+    List<String> stillThere = subjectsOf(junk);
+    assertTrue(stillThere.toString(), stillThere.contains("Cheap pills 0"));
+    assertTrue(stillThere.toString(), stillThere.contains("Cheap pills 1"));
+  }
+
+  @Test
+  public void reportsFailureWhenADeletionCannotBeConfirmed() throws Exception {
+    fillJunk(2);
+    IMAPFolder junk = EmailHandler.getFolder(store, JUNK);
+    IMAPFolder inbox = EmailHandler.getFolder(store, INBOX);
+    Message[] messagesFromAnotherFolder = junk.getMessages();
+
+    // deleteMessages documents that the messages have to belong to the folder. Handing it
+    // messages from elsewhere means the expunge cannot change the folder's count, so the
+    // retry loop has to run out and report a failure rather than claim success.
+    long startedAt = System.currentTimeMillis();
+    assertFalse(EmailHandler.deleteMessages(inbox, messagesFromAnotherFolder));
+
+    assertTrue("the retry loop should have polled, not returned immediately",
+        System.currentTimeMillis() - startedAt >= 5_000L);
+    assertEquals(0, inbox.getMessageCount());
+  }
+
+  @Test
+  public void deletesMessagesFromTheFolderTheyBelongTo() throws Exception {
+    fillJunk(2);
+    IMAPFolder junk = EmailHandler.getFolder(store, JUNK);
+    Message[] all = junk.getMessages();
+
+    assertTrue(EmailHandler.deleteMessages(junk, all));
+
+    assertEquals(0, junk.getMessageCount());
+  }
+
+  @Test
+  public void copyMessagesLeavesTheSourceFolderUntouched() throws Exception {
+    fillJunk(2);
+    IMAPFolder junk = EmailHandler.getFolder(store, JUNK);
+    IMAPFolder inbox = EmailHandler.getFolder(store, INBOX);
+
+    assertTrue(EmailHandler.copyMessages(junk, inbox, junk.getMessages()));
+
+    assertEquals(2, junk.getMessageCount());
+    assertEquals(2, inbox.getMessageCount());
+  }
+
+  @Test
+  public void checkAmountAgreesWithTheServerCount() throws Exception {
+    fillJunk(2);
+    IMAPFolder junk = EmailHandler.getFolder(store, JUNK);
+
+    assertTrue(EmailHandler.checkAmount(junk, 2));
+  }
+
+  @Test
+  public void listsTheMailboxesOnTheServer() throws Exception {
+    PrintStream original = System.out;
+    ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(captured, true));
+    try {
+      EmailHandler.printFolderList(store);
+    } finally {
+      System.setOut(original);
+    }
+
+    String listed = captured.toString("UTF-8");
+    assertTrue(listed, listed.contains(">> INBOX"));
+    assertTrue(listed, listed.contains(">> " + JUNK));
+  }
+}

--- a/src/test/java/martinfrancois/EmailHandlerMainTest.java
+++ b/src/test/java/martinfrancois/EmailHandlerMainTest.java
@@ -1,0 +1,164 @@
+package martinfrancois;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Drives {@link EmailHandler#main(String[])} end to end.
+ *
+ * <p>The hosts handed to main point at loopback, where nothing answers on the IMAPS port, so
+ * every run gets as far as a real JavaMail {@code imaps} connection attempt and then fails. That
+ * is deliberate: the assertions are made on what the failure produced, which means Guava's
+ * {@code Throwables.getStackTraceAsString} and the Log4j configuration in
+ * {@code src/main/resources/log4j2.xml} both have to still work for the test to pass.
+ */
+public class EmailHandlerMainTest {
+
+  private static final String UNREACHABLE_HOST = "127.0.0.1";
+  private static final String VALUE_SUFFIX = "_VALUE";
+
+  private static final Preferences NODE =
+      Preferences.userNodeForPackage(SecurePreferences.class);
+
+  private InputStream originalIn;
+  private PrintStream originalOut;
+  private ByteArrayOutputStream captured;
+
+  @Before
+  public void captureConsole() {
+    originalIn = System.in;
+    originalOut = System.out;
+    captured = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(captured, true));
+  }
+
+  @After
+  public void restoreConsole() throws BackingStoreException {
+    System.setIn(originalIn);
+    System.setOut(originalOut);
+    NODE.clear();
+  }
+
+  private void answerPasswordPrompts(int times) {
+    StringBuilder answers = new StringBuilder();
+    for (int i = 0; i < times; i++) {
+      answers.append("s3cret").append(System.lineSeparator());
+    }
+    System.setIn(new ByteArrayInputStream(answers.toString().getBytes()));
+  }
+
+  private String console() throws UnsupportedEncodingException {
+    return captured.toString("UTF-8");
+  }
+
+  private static int countOf(String haystack, String needle) {
+    int count = 0;
+    for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + 1)) {
+      count++;
+    }
+    return count;
+  }
+
+  @Test
+  public void rejectsAnArgumentCountThatIsNotAWholeNumberOfAccounts() throws IOException {
+    LogFile events = LogFile.mark(LogFile.EVENTS);
+
+    EmailHandler.main(new String[] {"imap.example.com", "smtp.example.com"});
+
+    String log = events.appended();
+    assertTrue(log, log.contains("Incorrect number of arguments found (2)"));
+    // No account was processed, so no connection was attempted.
+    assertFalse(log, log.contains("Trying to connect to host"));
+  }
+
+  @Test
+  public void treatsEveryThreeArgumentsAsOneAccount() throws IOException {
+    // main builds a fresh Scanner per account and the first one buffers ahead, so two
+    // prompts cannot be answered from a single stream. Seed both passwords first.
+    answerPasswordPrompts(1);
+    EmailHandler.main(new String[] {UNREACHABLE_HOST, UNREACHABLE_HOST, "first@example.com"});
+    answerPasswordPrompts(1);
+    EmailHandler.main(new String[] {UNREACHABLE_HOST, UNREACHABLE_HOST, "second@example.com"});
+
+    LogFile events = LogFile.mark(LogFile.EVENTS);
+    System.setIn(new ByteArrayInputStream(new byte[0]));
+    EmailHandler.main(new String[] {
+        UNREACHABLE_HOST, UNREACHABLE_HOST, "first@example.com",
+        UNREACHABLE_HOST, UNREACHABLE_HOST, "second@example.com"});
+
+    String log = events.appended();
+    assertTrue(log, log.contains("with user: first@example.com"));
+    assertTrue(log, log.contains("with user: second@example.com"));
+  }
+
+  @Test
+  public void treatsATrailingArgumentAsTheForwardingRecipient() throws IOException {
+    answerPasswordPrompts(1);
+    LogFile events = LogFile.mark(LogFile.EVENTS);
+
+    EmailHandler.main(new String[] {
+        UNREACHABLE_HOST, UNREACHABLE_HOST, "fwd@example.com", "postmaster@example.com"});
+
+    String log = events.appended();
+    // Four arguments is one account plus a recipient, not an argument count error.
+    assertTrue(log, log.contains("with user: fwd@example.com"));
+    assertFalse(log, log.contains("Incorrect number of arguments"));
+  }
+
+  @Test
+  public void promptsOnlyOnceAndReusesTheStoredPassword() throws IOException {
+    answerPasswordPrompts(1);
+    String[] args = {UNREACHABLE_HOST, UNREACHABLE_HOST, "reuse@example.com"};
+
+    EmailHandler.main(args);
+    // The second run gets an empty stdin: had it prompted again, Scanner would have thrown.
+    System.setIn(new ByteArrayInputStream(new byte[0]));
+    EmailHandler.main(args);
+
+    assertEquals(console(), 1,
+        countOf(console(), "Please enter password for user: reuse@example.com"));
+    assertNotEquals("", NODE.get("reuse@example.com" + VALUE_SUFFIX, ""));
+  }
+
+  @Test
+  public void withoutArgumentsClearsEveryStoredCredential() throws IOException {
+    answerPasswordPrompts(1);
+    EmailHandler.main(new String[] {UNREACHABLE_HOST, UNREACHABLE_HOST, "wipe@example.com"});
+    assertNotEquals("", NODE.get("wipe@example.com" + VALUE_SUFFIX, ""));
+
+    LogFile events = LogFile.mark(LogFile.EVENTS);
+    EmailHandler.main(new String[0]);
+
+    assertEquals("absent", NODE.get("wipe@example.com" + VALUE_SUFFIX, "absent"));
+    assertTrue(events.appended(), events.appended().contains("Preferences cleared"));
+  }
+
+  @Test
+  public void logsTheFullStackTraceOfAFailedConnection() throws IOException {
+    answerPasswordPrompts(1);
+    LogFile stackTraces = LogFile.mark(LogFile.STACK_TRACES);
+
+    EmailHandler.main(new String[] {UNREACHABLE_HOST, UNREACHABLE_HOST, "trace@example.com"});
+
+    String trace = stackTraces.appended();
+    // Produced by Guava's Throwables and routed by the "Exception" logger in log4j2.xml.
+    assertTrue(trace, trace.contains("com.sun.mail.util.MailConnectException"));
+    assertTrue(trace, trace.contains("java.net.ConnectException"));
+    assertTrue(trace, trace.contains("com.sun.mail.imap.IMAPStore.protocolConnect"));
+    assertTrue(trace, trace.contains("martinfrancois.EmailHandler.moveSpam"));
+  }
+}

--- a/src/test/java/martinfrancois/LogFile.java
+++ b/src/test/java/martinfrancois/LogFile.java
@@ -1,0 +1,49 @@
+package martinfrancois;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+
+/**
+ * Reads back what log4j2.xml actually wrote to disk.
+ *
+ * <p>The appender layout, the file names and the routing of the "Exception" logger all live in
+ * {@code src/main/resources/log4j2.xml}. Asserting on the files rather than on a captured
+ * appender means a Log4j upgrade that can no longer read that configuration fails the build
+ * instead of silently logging nowhere.
+ */
+final class LogFile {
+
+  /** Relative to the surefire working directory, which the build points at {@code target/}. */
+  static final String EVENTS = "logs/junkMoverEvents.log";
+
+  static final String STACK_TRACES = "logs/junkMoverStackTrace.log";
+
+  private final File file;
+  private final long offset;
+
+  private LogFile(File file, long offset) {
+    this.file = file;
+    this.offset = offset;
+  }
+
+  /**
+   * Marks the current end of the given log file. Everything appended after this point is returned
+   * by {@link #appended()}, so assertions never accidentally pass on output left behind by an
+   * earlier test or an earlier build.
+   */
+  static LogFile mark(String path) {
+    File file = new File(path);
+    return new LogFile(file, file.isFile() ? file.length() : 0L);
+  }
+
+  String appended() throws IOException {
+    if (!file.isFile()) {
+      return "";
+    }
+    byte[] all = Files.readAllBytes(file.toPath());
+    int start = (int) Math.min(offset, all.length);
+    return new String(all, start, all.length - start, Charset.defaultCharset());
+  }
+}

--- a/src/test/java/martinfrancois/SecurePreferencesEncryptionTest.java
+++ b/src/test/java/martinfrancois/SecurePreferencesEncryptionTest.java
@@ -1,0 +1,146 @@
+package martinfrancois;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Base64;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Exercises {@link SecurePreferences} against the real JCE provider and the real
+ * {@link Preferences} backing store; nothing here is stubbed.
+ */
+public class SecurePreferencesEncryptionTest {
+
+  /** The very same node {@link SecurePreferences} writes to. */
+  private static final Preferences NODE =
+      Preferences.userNodeForPackage(SecurePreferences.class);
+
+  private static final String KEY_PREF = "secretKey";
+  private static final String VALUE_SUFFIX = "_VALUE";
+  private static final String IV_SUFFIX = "_IV";
+
+  @Before
+  @After
+  public void clearPreferences() throws BackingStoreException {
+    NODE.clear();
+  }
+
+  @Test
+  public void roundTripsAValueTooLongForASingleBase64Line() {
+    StringBuilder password = new StringBuilder();
+    for (int i = 0; i < 200; i++) {
+      password.append((char) ('a' + (i % 26)));
+    }
+    String secret = password.toString();
+
+    SecurePreferences prefs = new SecurePreferences();
+    prefs.resetSecretKey();
+    prefs.savePref("long", secret);
+
+    // Base64 of a >76 byte ciphertext used to be written with embedded line breaks, which
+    // java.util.Base64's basic decoder rejects, so the value could be stored but never read.
+    assertEquals(-1, NODE.get("long" + VALUE_SUFFIX, "").indexOf('\n'));
+    assertEquals(secret, prefs.loadPref("long"));
+  }
+
+  @Test
+  public void roundTripsThroughAFreshInstanceUsingTheStoredKey() {
+    SecurePreferences writer = new SecurePreferences();
+    writer.resetSecretKey();
+    writer.savePref("shared", "hunter2");
+
+    // A second instance has to rebuild the key from the preferences node.
+    assertEquals("hunter2", new SecurePreferences().loadPref("shared"));
+  }
+
+  @Test
+  public void returnsAnEmptyStringForAKeyThatWasNeverStored() {
+    SecurePreferences prefs = new SecurePreferences();
+    prefs.resetSecretKey();
+
+    assertEquals("", prefs.loadPref("never-stored"));
+  }
+
+  @Test
+  public void generatesAFreshKeyWhenTheStoredOneIsUnusable() {
+    NODE.put(KEY_PREF, ""); // decodes to a zero length key, which AES rejects
+
+    SecurePreferences prefs = new SecurePreferences();
+    prefs.savePref("recovered", "value");
+
+    assertNotEquals("", NODE.get(KEY_PREF, ""));
+    assertEquals("value", prefs.loadPref("recovered"));
+  }
+
+  @Test
+  public void returnsNullWhenTheStoredCiphertextCannotBeDecrypted() {
+    SecurePreferences prefs = new SecurePreferences();
+    prefs.resetSecretKey();
+    prefs.savePref("tampered", "value");
+
+    // Ten bytes is not a whole number of AES blocks, so the cipher fails deterministically
+    // rather than depending on whether random bytes happen to carry valid padding.
+    NODE.put("tampered" + VALUE_SUFFIX, Base64.getEncoder().encodeToString(new byte[10]));
+
+    assertNull(new SecurePreferences().loadPref("tampered"));
+  }
+
+  @Test
+  public void storesNothingUsableWhenTheKeyIsTheWrongLength() {
+    // A five byte key survives SecretKeySpec but is rejected by Cipher.init.
+    NODE.put(KEY_PREF, Base64.getEncoder().encodeToString(new byte[5]));
+
+    SecurePreferences prefs = new SecurePreferences();
+    prefs.savePref("broken", "value");
+
+    // Documents today's behaviour: the failure is logged and an empty value is written,
+    // which reads back as "not stored" rather than as the plaintext.
+    assertEquals("", NODE.get("broken" + VALUE_SUFFIX, "absent"));
+    assertEquals("", prefs.loadPref("broken"));
+  }
+
+  @Test
+  public void resetPrefsWipesStoredValuesAndInstallsANewKey() {
+    SecurePreferences prefs = new SecurePreferences();
+    prefs.resetSecretKey();
+    prefs.savePref("wiped", "value");
+    String keyBefore = NODE.get(KEY_PREF, "");
+    assertNotEquals("", keyBefore);
+
+    prefs.resetPrefs();
+
+    assertEquals("absent", NODE.get("wiped" + VALUE_SUFFIX, "absent"));
+    assertNull(NODE.getByteArray("wiped" + IV_SUFFIX, null));
+    String keyAfter = NODE.get(KEY_PREF, "");
+    assertNotEquals("", keyAfter);
+    assertNotEquals(keyBefore, keyAfter);
+  }
+
+  @Test
+  public void usesARandomInitialisationVectorPerWrite() {
+    SecurePreferences prefs = new SecurePreferences();
+    prefs.resetSecretKey();
+
+    prefs.savePref("iv", "value");
+    String firstCiphertext = NODE.get("iv" + VALUE_SUFFIX, "");
+    byte[] firstIv = NODE.getByteArray("iv" + IV_SUFFIX, null);
+
+    prefs.savePref("iv", "value");
+    String secondCiphertext = NODE.get("iv" + VALUE_SUFFIX, "");
+    byte[] secondIv = NODE.getByteArray("iv" + IV_SUFFIX, null);
+
+    assertEquals(16, firstIv.length);
+    assertNotEquals(Base64.getEncoder().encodeToString(firstIv),
+        Base64.getEncoder().encodeToString(secondIv));
+    assertNotEquals(firstCiphertext, secondCiphertext);
+    assertTrue(firstCiphertext.length() > 0);
+    assertEquals("value", prefs.loadPref("iv"));
+  }
+}


### PR DESCRIPTION
This repository was missed in the fleet pass because it uses Dependabot and has no `renovate.json`. It also had **no CI of any kind**.

## It did not build

`mvn -B verify` failed before anything else was possible. `pom.xml` declared open-ended ranges (`[1.6.0,]`, `[2.8.2,]`), which now resolve Log4j to `3.0.0-beta` (Java 17 bytecode) against a Java 8 target:

```
bad class file: log4j-api-3.0.0-beta2.jar(org/apache/logging/log4j/Level.class)
  class file has wrong version 61.0, should be 52.0
```

Pinned to `javax.mail 1.6.2` and `log4j 2.26.1`, the newest release still shipping Java 8 bytecode (verified by reading the jars). An open range is also invisible to any update bot and bypasses `minimumReleaseAge` entirely.

## A real bug, found by testing the real dependency

`SecurePreferences` encrypted with `sun.misc.BASE64Encoder`, which line-wraps at 76 characters, but decrypted with `java.util.Base64`, which rejects line breaks. **Any password longer than about 40 characters could be stored and then never read back.** `sun.misc.BASE64Encoder` was also removed in Java 9.

## CI and coverage

New `build` job on `pull_request` and `push`, actions digest-pinned with tag comments, Java version taken from `pom.xml` rather than guessed.

Coverage **19.06% (210/1102) to 84.64% (931/1100)**, 26 tests. The gate is real, proven by deleting a test file:

```
Rule violated for bundle junkEmailMover: instructions covered ratio is 0.47,
  but expected minimum is 0.80
BUILD FAILURE
```

Tests exercise the actual dependencies: GreenMail runs real IMAP and SMTP servers on loopback, so folder open, APPEND, COPY, the DELETED flag, EXPUNGE, MIME multipart assembly and SMTP delivery all travel over a socket. Assertions read back the files `log4j2.xml` declares, so a Log4j upgrade that cannot parse that config fails the build. Two tests cover the invariant the program exists for: nothing is deleted unless copy and forward both succeeded.

## Dependabot to Renovate

`.github/dependabot.yml` removed. The new config matches the fleet: no `group:all`, non-major bundled and automergeable, majors ungrouped with `automerge: false`, seven-day `minimumReleaseAge` with `timestamp-required` and `internalChecksFilter: strict`, `pinDigests`, vulnerability alerts. Public repository, so `separateMultipleMajor` is `true`.

**The custom managers were validated by running real Renovate (`--platform=local --dry-run=full`), not just the schema validator.** That caught a trap the validator cannot see: `config:recommended` pulls in `workarounds:javaVersions`, which made Renovate want to write `<source>8.0.502+7</source>`, a value `maven-compiler-plugin` rejects. The first fix attempt then produced a manager that silently matched **zero** dependencies. Both were only visible by running the real thing.

## Supersedes

- Dependabot #34, #35, #36, all covered by the `all-non-major` bundle
- Snyk #30 (guava 33.4.6), superseded by 33.6.0 in the same bundle
- Renovate onboarding #37 becomes redundant once this reaches `master`