### PR TITLE
ci: verify the build on Java 8, 11, 17, 21 and 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,22 +13,29 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
-    name: build
+  test:
+    name: test (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
+    strategy:
+      # The point of the matrix is to learn which Java versions work. fail-fast
+      # would cancel the remaining legs as soon as one broke and hide that answer
+      # for every version after the first failure.
+      fail-fast: false
+      matrix:
+        # Every version listed here was observed to pass `mvn -B verify`; see the
+        # support table in README.md. The lowest entry is also the release level
+        # maven-compiler-plugin targets in pom.xml.
+        java: ["8", "11", "17", "21", "25"]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # maven-compiler-plugin in pom.xml is configured with source/target 1.8. Keep this
-      # java-version and that configuration in step; renovate.json groups them so they
-      # are always proposed together.
-      - name: Set up Java 8
+      - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
-          java-version: "8"
+          java-version: ${{ matrix.java }}
           cache: maven
       - name: Verify
         run: mvn -B verify
@@ -36,6 +43,34 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage
+          # One artifact per leg. upload-artifact rejects a second upload under a
+          # name that already exists, so the legs cannot share one.
+          name: coverage-java-${{ matrix.java }}
           if-no-files-found: ignore
           path: target/site/jacoco
+
+  # The branch ruleset requires a status check whose context is exactly "build".
+  # Turning the old single "build" job into a matrix would have renamed its
+  # contexts to "build (8)", "build (11)", ... and the required check would have
+  # matched nothing, leaving the branch ungated. This job keeps the "build"
+  # context in existence and carries the matrix result into it.
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs: [test]
+    # Without always() this job is skipped whenever a leg fails, and a skipped
+    # required check does not block a merge: the branch would silently go green
+    # on a broken build. always() runs it regardless, and the step below decides.
+    if: always()
+    steps:
+      - name: Require every Java version to have passed
+        env:
+          # For a matrix job this is the aggregate: "success" only when every leg
+          # succeeded, otherwise "failure", "cancelled" or "skipped".
+          RESULT: ${{ needs.test.result }}
+        run: |
+          echo "Matrix result: ${RESULT}"
+          if [ "${RESULT}" != "success" ]; then
+            echo "::error::At least one Java version did not pass (matrix result: ${RESULT})."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -9,9 +9,37 @@ second pair of eyes on what the filter caught. Nothing is deleted from `Junk` un
 
 ## Requirements
 
-- Java 8 or newer at runtime.
 - An IMAP account reachable over `imaps`, and an SMTP host that accepts STARTTLS.
 - The mailbox must have folders literally named `Junk` and `Inbox`.
+- A Java runtime, see below.
+
+### Java versions
+
+CI runs the full build, `mvn -B verify`, on every version in this table, so a version is listed as
+supported only because a build on it was seen to pass.
+
+| Version | `mvn -B verify` | Notes |
+| --- | --- | --- |
+| 8 | passes | The minimum. Also the bytecode level the jar is compiled to. |
+| 11 | passes | |
+| 17 | passes | |
+| 21 | passes | javac warns `source value 8 is obsolete and will be removed in a future release`. A warning, not an error; the build passes. |
+| 25 | passes | Same obsolescence warning as 21. |
+
+**Nothing is excluded.** All five were tried and all five passed, so no dependency currently forces
+a minimum above Java 8 and there is no version to leave out. If that changes, the offending version
+gets a row here with the reason rather than being quietly dropped.
+
+Only those five were tested. The non-LTS releases in between (9, 10, 12-16, 18-20, 22-24) are
+neither supported nor known to be broken; nobody has run them.
+
+Two limits on what the table claims:
+
+- A row means that JDK compiled the project and ran the whole test suite. It is a statement about
+  building, not a separate statement about every runtime.
+- The runtime minimum is Java 8 because `maven.compiler.release` is 8, which pins the compiler to
+  the Java 8 API regardless of which JDK does the building. Without it a jar built on a newer JDK
+  can link against methods a Java 8 JRE does not have and fail only when it is run.
 
 ## Build
 
@@ -99,6 +127,12 @@ mvn -B verify        # tests plus the 80% coverage gate
 
 Tests run against real IMAP and SMTP servers provided by GreenMail on loopback, rather than against
 mocks, so a dependency upgrade that changes protocol behaviour fails the build rather than shipping.
+
+CI runs that command once per Java version in the table above. The legs report as `test (Java 8)`,
+`test (Java 11)` and so on, and a separate job named `build` depends on them and fails unless every
+leg passed. `build` is the required status check on `master`, so do not rename it: a matrix leg
+cannot take its place, and dropping it would leave the branch with a required check that matches
+no job at all.
 
 Dependencies are managed by Renovate. Non-major updates are grouped into a single pull request that
 merges automatically once CI passes; major updates arrive separately and require review.

--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,17 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <!-- Same literal as java-version in .github/workflows/ci.yml, which is
-                         what lets renovate.json track and move the two together. -->
-                    <source>8</source>
-                    <target>8</target>
+                    <!-- The lowest version in the CI matrix in .github/workflows/ci.yml, and
+                         the minimum JRE the shaded jar is claimed to run on. renovate.json
+                         tracks this literal.
+                         release, not source/target: source/target still links against the
+                         JDK running the build, so a build on anything newer than 8 "may lead
+                         to class files that cannot run on JDK 8" (javac's own warning), and
+                         the matrix builds on five different JDKs. release sets the bootstrap
+                         class path, so every leg emits the same Java 8 bytecode. On JDK 8,
+                         whose javac predates the release flag, maven-compiler-plugin
+                         translates this back to source 1.8 and target 1.8. -->
+                    <release>8</release>
                 </configuration>
             </plugin>
 

--- a/renovate.json
+++ b/renovate.json
@@ -27,21 +27,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "The JDK the CI job installs. No built-in manager reads the java-version input of actions/setup-java.",
-      "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
-      "matchStrings": ["java-version:\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "java",
-      "datasourceTemplate": "java-version",
-      "versioningTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "description": "The language level maven-compiler-plugin targets. The maven manager reads plugin versions but not plugin configuration.",
+      "description": "The minimum language level maven-compiler-plugin targets. The maven manager reads plugin versions but not plugin configuration. There is deliberately no companion manager for .github/workflows: the java-version input is now ${{ matrix.java }}, and the matrix itself is a hand-maintained list of the versions CI was observed to pass on, not a single version that can be bumped.",
       "managerFilePatterns": ["/(^|/)pom\\.xml$/"],
-      "matchStrings": [
-        "<source>(?<currentValue>[^<]+)</source>",
-        "<target>(?<currentValue>[^<]+)</target>"
-      ],
+      "matchStrings": ["<release>(?<currentValue>[^<]+)</release>"],
       "depNameTemplate": "java",
       "datasourceTemplate": "java-version",
       "versioningTemplate": "docker"
@@ -73,9 +61,9 @@
       "groupName": "log4j"
     },
     {
-      "description": "Lockstep: the JDK the CI job installs and the language level maven-compiler-plugin targets are the same number written in two files. If the pom asks for a release newer than the installed JDK, javac refuses to compile; if it asks for an older one, CI publishes bytecode for a runtime it never ran a test on. Both references are named java, so this one rule moves all three occurrences in a single branch. Raising the language level also raises the minimum JRE for the shaded jar this project publishes, which is a maintainer's decision, so dependencyDashboardApproval holds the move until a human ticks the box rather than opening the pull request unprompted.",
+      "description": "The minimum Java version, held in maven.compiler.release in pom.xml. CI no longer builds on one JDK, it builds on every version in the matrix in .github/workflows/ci.yml, so the old lockstep between a single installed JDK and the language level no longer applies: the pom now states the floor and the matrix states the tested set. Raising the floor raises the minimum JRE for the shaded jar this project publishes and means dropping the matrix legs below it, which is a maintainer's decision, so dependencyDashboardApproval holds the move until a human ticks the box rather than opening the pull request unprompted.",
       "matchDepNames": ["java"],
-      "groupName": "java toolchain",
+      "groupName": "java minimum version",
       "extractVersion": "^(?<version>\\d+)",
       "versioning": "docker",
       "dependencyDashboardApproval": true


### PR DESCRIPTION
## Results

Every JDK was run locally with `mvn -B clean verify`, then re-confirmed on real GitHub Actions (run 31195200384, all green).

| JDK (Temurin) | Result | Tests |
|---|---|---|
| 8.0.492+9 | **PASS** | 26/26 |
| 11.0.31+11 | **PASS** | 26/26 |
| 17.0.19+10 | **PASS** | 26/26 |
| 21.0.11+10.0.LTS | **PASS** | 26/26 |
| 25.0.1+8.0.LTS | **PASS** | 26/26 |

**No failures anywhere, so the minimum stays Java 8.** Nothing was raised speculatively.

## The one real fix: `release` instead of `source`/`target`

`maven-compiler-plugin` moves from `<source>8</source><target>8</target>` to `<release>8</release>`. This does not change the minimum; it makes the existing one actually enforced. javac's own warning on JDK 25:

```
bootstrap class path is not set in conjunction with -source 8
  not setting the bootstrap class path may lead to class files that cannot run on JDK 8
    --release 8 is recommended instead of -source 8 -target 8
```

With `source`/`target`, javac links against whichever JDK runs the build, so the Java 8 runtime claim was unbacked as soon as CI built on five JDKs. Verified: the jar built on JDK 25 has class-file major version 52 and was executed successfully on the Java 8 JRE.

## The aggregation trap, and proof it is closed

`build` is the required status check in the repository ruleset. A naive matrix renames the contexts to `build (8)`, `build (11)`… which would leave the ruleset requiring a check that no longer exists: a branch that looks protected but is not.

So the matrix runs as `test (Java N)` and a single aggregating job named exactly **`build`** gates on it. Proven with two real runs on a temporary branch, since deleted:

- **Green** (31195200384): five legs pass, `build` succeeds. The check-runs API confirms the context is literally `build` from app 15368, the exact string the ruleset requires.
- **Broken leg** (31195369772): Java 17 forced to fail. `test (Java 17)` failed, the other four still ran (`fail-fast: false`), and **`build` reported failure rather than being skipped.**

That last part matters: `needs:` alone would have *skipped* the aggregator, and a skipped required check does not block a merge. The `if: always()` plus an explicit `needs.test.result` check is what makes it gate.

## Renovate config, which would otherwise have broken silently

The pom custom manager matched `<source>`/`<target>`, which no longer exist, and the workflow manager matched a literal quoted `java-version:` that a matrix does not have. Both updated; the workflow one is removed with the reasoning recorded, since a matrix is a hand-maintained set rather than a bumpable version.

## README

Now states exactly which versions are verified and that non-LTS releases in between were not tested, rather than implying they work.

## Correction to an assumption

Open PR #40 (greenmail v2) fails `build`, and **raising the Java floor would not fix it**. The blocker is the namespace:

```
incompatible types: jakarta.mail.internet.MimeMessage cannot be converted to javax.mail.internet.MimeMessage
```

GreenMail 2.x speaks `jakarta.mail` while the production code uses `com.sun.mail:javax.mail` 1.6.2. That is handled separately.