### PR TITLE
build(deps): update greenmail to v2 and migrate to Jakarta Mail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,17 +119,22 @@
     </build>
 
     <dependencies>
-        <!-- JavaMail API -->
+        <!-- Jakarta Mail. Angus Mail is the reference implementation of the
+             jakarta.mail-api it pulls in, and the successor of the com.sun.mail
+             JavaMail line this project used while it spoke the javax.mail namespace.
+             angus-mail (implementation only) is deliberately preferred over the
+             org.eclipse.angus:jakarta.mail uber jar, which repackages the API classes
+             as well and would put two copies of jakarta.mail.* on the classpath. -->
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>1.6.2</version>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
+            <version>2.0.5</version>
         </dependency>
 
         <!-- Log4j. log4j-core requires the exact same version of log4j-api, so the
              two share a single property and are upgraded in lockstep.
-             Log4j 3.x requires Java 17 and is therefore out of reach while this
-             project targets Java 8. -->
+             Log4j 3.x has no stable release yet (3.0.0-beta3 is the newest artifact on
+             Maven Central), so 2.x is still the current line. -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
@@ -154,19 +159,19 @@
         </dependency>
 
         <!-- Real in-process IMAP and SMTP servers, so the tests drive the actual
-             JavaMail protocol implementation instead of a mock of it.
-             GreenMail 1.6.x is the last line that speaks the javax.mail namespace;
-             2.x requires jakarta.mail 2 and Java 11.
-             Its own JavaMail copy is excluded so the tests run against exactly the
-             com.sun.mail:javax.mail version this project ships. -->
+             Jakarta Mail protocol implementation instead of a mock of it.
+             GreenMail 2.x speaks jakarta.mail, which is why this project no longer
+             ships com.sun.mail:javax.mail.
+             Its own uber jar copy of Angus Mail is excluded so the tests run against
+             exactly the org.eclipse.angus:angus-mail version this project ships. -->
         <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
-            <version>1.6.15</version>
+            <version>2.1.11</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>com.sun.mail</groupId>
+                    <groupId>org.eclipse.angus</groupId>
                     <artifactId>jakarta.mail</artifactId>
                 </exclusion>
             </exclusions>

--- a/src/main/java/martinfrancois/EmailHandler.java
+++ b/src/main/java/martinfrancois/EmailHandler.java
@@ -2,28 +2,28 @@ package martinfrancois;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
-import com.sun.mail.imap.IMAPFolder;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Flags;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.NoSuchProviderException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 import java.util.Date;
 import java.util.Properties;
 import java.util.Scanner;
 import java.util.concurrent.TimeUnit;
-import javax.mail.BodyPart;
-import javax.mail.Flags;
-import javax.mail.Folder;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Multipart;
-import javax.mail.NoSuchProviderException;
-import javax.mail.Session;
-import javax.mail.Store;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.angus.mail.imap.IMAPFolder;
 
 /**
  * Created by François Martin on 10.09.2017.
@@ -162,7 +162,7 @@ public class EmailHandler {
    */
   @VisibleForTesting
   static boolean moveMessages(Folder from, Folder to, Message[] messages, Settings settings) throws MessagingException {
-    // get a list of javamail messages as an array of messages
+    // get a list of Jakarta Mail messages as an array of messages
     if (messages == null) {
       LOGGER.trace("messages is null, copying all messages");
       // get all messages

--- a/src/test/java/martinfrancois/EmailHandlerMailboxTest.java
+++ b/src/test/java/martinfrancois/EmailHandlerMailboxTest.java
@@ -8,20 +8,20 @@ import static org.junit.Assert.assertTrue;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetup;
-import com.sun.mail.imap.IMAPFolder;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Properties;
-import javax.mail.Folder;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.Store;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
+import org.eclipse.angus.mail.imap.IMAPFolder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,10 +30,10 @@ import org.junit.Test;
  * Runs the mailbox handling against real IMAP and SMTP servers.
  *
  * <p>GreenMail speaks the actual protocols over a socket, so every assertion here goes through
- * the {@code com.sun.mail} implementation: folder open, APPEND, COPY, the DELETED flag, EXPUNGE,
- * MIME multipart assembly and SMTP delivery. Mocking JavaMail would make these tests pass no
- * matter which version of JavaMail is on the classpath, which is exactly what they are meant to
- * detect.
+ * the {@code org.eclipse.angus.mail} implementation: folder open, APPEND, COPY, the DELETED flag,
+ * EXPUNGE, MIME multipart assembly and SMTP delivery. Mocking Jakarta Mail would make these tests
+ * pass no matter which version of Jakarta Mail is on the classpath, which is exactly what they are
+ * meant to detect.
  */
 public class EmailHandlerMailboxTest {
 
@@ -215,7 +215,7 @@ public class EmailHandlerMailboxTest {
     assertFalse(EmailHandler.forwardMessage(message, settings("this is not an address")));
 
     String trace = stackTraces.appended();
-    assertTrue(trace, trace.contains("javax.mail.internet.AddressException"));
+    assertTrue(trace, trace.contains("jakarta.mail.internet.AddressException"));
   }
 
   @Test

--- a/src/test/java/martinfrancois/EmailHandlerMainTest.java
+++ b/src/test/java/martinfrancois/EmailHandlerMainTest.java
@@ -20,8 +20,8 @@ import org.junit.Test;
 /**
  * Drives {@link EmailHandler#main(String[])} end to end.
  *
- * <p>The hosts handed to main point at loopback, where nothing answers on the IMAPS port, so
- * every run gets as far as a real JavaMail {@code imaps} connection attempt and then fails. That
+ * <p>The hosts handed to main point at loopback, where nothing answers on the IMAPS port, so every
+ * run gets as far as a real Jakarta Mail {@code imaps} connection attempt and then fails. That
  * is deliberate: the assertions are made on what the failure produced, which means Guava's
  * {@code Throwables.getStackTraceAsString} and the Log4j configuration in
  * {@code src/main/resources/log4j2.xml} both have to still work for the test to pass.
@@ -156,9 +156,9 @@ public class EmailHandlerMainTest {
 
     String trace = stackTraces.appended();
     // Produced by Guava's Throwables and routed by the "Exception" logger in log4j2.xml.
-    assertTrue(trace, trace.contains("com.sun.mail.util.MailConnectException"));
+    assertTrue(trace, trace.contains("org.eclipse.angus.mail.util.MailConnectException"));
     assertTrue(trace, trace.contains("java.net.ConnectException"));
-    assertTrue(trace, trace.contains("com.sun.mail.imap.IMAPStore.protocolConnect"));
+    assertTrue(trace, trace.contains("org.eclipse.angus.mail.imap.IMAPStore.protocolConnect"));
     assertTrue(trace, trace.contains("martinfrancois.EmailHandler.moveSpam"));
   }
 }


### PR DESCRIPTION
Supersedes #40, which could not build: GreenMail 2.x speaks `jakarta.mail` while the production code used `com.sun.mail:javax.mail` 1.6.2.

```
incompatible types: jakarta.mail.internet.MimeMessage
  cannot be converted to javax.mail.internet.MimeMessage
```

Taking the major therefore means porting the production code, not bumping a test dependency.

## Release notes, read rather than skimmed

Every GitHub release between 1.6.15 and 2.1.11 was read. The breaking changes that actually apply:

| Release | Breaking change |
|---|---|
| 2.0.0-alpha-1 | "Jakarta Mail 2.0.0 … which also include package import changes `javax.mail` -> `jakarta.mail`" |
| 2.0.0 | "Jakarta Mail 2.0 : javax.mail -> jakarta.mail"; "Require Java 11 for building" |
| 2.0.0-alpha-3 | Removed deprecated `MailFolder#getUidNext()`; migrated off EOL log4j12 |
| 2.1.0-alpha-1 | "Migrate to Jakarta Mail 2.1 with **Angus Mail as default implementation**" |
| 2.1.0-rc-1 | IMAP Content-Type no longer upper-cased (#706) |
| 2.1.11 | Reject STORE/EXPUNGE/MOVE on a read-only selected mailbox (#1032) |

The last two do not apply here: no test asserts on Content-Type casing, and folders are opened `READ_WRITE`.

## Migration applied

- 21 imports moved `javax.mail` -> `jakarta.mail` across `EmailHandler.java` and the two test classes.
- `com.sun.mail.imap.IMAPFolder` -> `org.eclipse.angus.mail.imap.IMAPFolder`.
- `com.sun.mail:javax.mail:1.6.2` -> `org.eclipse.angus:angus-mail:2.0.5`. Chose `angus-mail` over `org.eclipse.angus:jakarta.mail` because `unzip -l` shows the latter is an uber jar carrying the API classes too (356 vs 207), which would put two copies of the API on the classpath. `dependency:tree` confirms exactly one API and one implementation.
- Stack-trace assertions retargeted to the classes now actually on the stack. **Assertion count and strength unchanged**; no test deleted, no assertion weakened.

## The Java floor stays at 8

The original branch also raised the toolchain 8 -> 25. That commit is **dropped**. Its own evidence argued against it, and I verified the artifacts directly:

```
angus-mail-2.0.5.jar        class-file major=52  -> Java 8
jakarta.mail-api-2.1.5.jar  class-file major=52  -> Java 8
greenmail-2.1.11.jar        class-file major=52  -> Java 8
```

"Require Java 11" in the 2.0.0 notes refers to *building* GreenMail, not to running against it.

Verified locally on every JDK in the matrix from #43, with `<release>8</release>` preserved:

| JDK | Result | Tests |
|---|---|---|
| 8 | BUILD SUCCESS | 26/26 |
| 11 | BUILD SUCCESS | 26/26 |
| 17 | BUILD SUCCESS | 26/26 |
| 21 | BUILD SUCCESS | 26/26 |
| 25 | BUILD SUCCESS | 26/26 |

Raising the floor would have narrowed what the project supports for no reason, and would have pre-empted the matrix that exists to answer exactly that question.