### PR TITLE
fix(build): scope junit to test so it is not shaded into the published jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,10 +146,15 @@
             <version>${log4j.version}</version>
         </dependency>
 
+        <!-- Test only. Without the scope this would default to compile, putting
+             junit and its transitive hamcrest-core on the runtime classpath and
+             shading them into the published jar. Nothing in src/main imports
+             junit. -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Closes #46.

`junit` was declared without a `<scope>`, so it defaulted to `compile` and it and its transitive `hamcrest-core` were shaded into the published jar.

## Measured effect

Same tree, `mvn -B clean verify`, jar named explicitly:

|                                | before    | after     | delta     |
| ------------------------------ | --------- | --------- | --------- |
| `org/junit` + `org/hamcrest` entries | 398 | 0 | -398 |
| all junit + hamcrest entries (incl. legacy `junit/` pkg) | 433 | 0 | -433 |
| jar bytes                      | 6714740   | 6284878   | -429862 (-6.40%) |
| jar entries                    | 4628      | 4193      | -435      |
| runtime-scope artifacts        | 14        | 12        | -2        |

Entry-level diff of the two listings: 435 removed, 0 added (350 `org/junit`, 48 `org/hamcrest`, 18 `junit/framework`, 7 `junit/extensions`, 6 `junit/runner`, 3 `junit/textui`, plus the two license files carried by exactly those two jars). `META-INF/LICENSE` and `META-INF/NOTICE` for the remaining dependencies are untouched.

`dependency:tree` now shows `junit:junit:jar:4.13.2:test` and `org.hamcrest:hamcrest-core:jar:1.3:test`.

## Full matrix, both before and after

Ten builds, all `BUILD SUCCESS`, JaCoCo 0.80 instruction gate met every time:

| JDK | version    | tests                  | jar before → after      | junit entries |
| --- | ---------- | ---------------------- | ----------------------- | ------------- |
| 8   | 1.8.0_492  | 26 run, 0 failed       | 6714600 → 6284738       | 398 → 0       |
| 11  | 11.0.31    | 26 run, 0 failed       | 6714568 → 6284706       | 398 → 0       |
| 17  | 17.0.19    | 26 run, 0 failed       | 6714740 → 6284878       | 398 → 0       |
| 21  | 21.0.11    | 26 run, 0 failed       | 6714739 → 6284877       | 398 → 0       |
| 25  | 25.0.1     | 26 run, 0 failed       | 6714739 → 6284877       | 398 → 0       |

Delta is exactly -429862 bytes on all five. The jar still runs identically before and after, with byte-identical program output and no `NoClassDefFoundError`.

## The measurement is not a constant

A/B/A on JDK 17: fixed tree gives count 0 / 6284878 bytes; removing `<scope>test</scope>` gives 398 / 6714847; restoring gives exactly 0 / 6284878 again.

The 107-byte gap between that broken-state jar (6714847) and master's own build (6714740) is the explanatory comment added next to the dependency, which Maven embeds at `META-INF/maven/.../pom.xml` (8261 → 8557 bytes uncompressed, 107 deflated). So the pure junit + hamcrest removal is 429969 bytes and the net shipped change is 429862.

## Audit of the other dependencies

`junit` was the only mis-scoped one.

- `greenmail` already `test`, and its transitive `slf4j-api` with it.
- `angus-mail` `compile` is correct: `EmailHandler` imports `org.eclipse.angus.mail.imap.IMAPFolder` in 7 places.
- `log4j-api` `compile` is correct.
- `log4j-core` `compile` is correct and deliberately left alone despite `dependency:analyze` flagging it unused. That is a known false positive: it is the runtime backend configured by `src/main/resources/log4j2.xml`, invisible to bytecode analysis. Test-scoping it would break the shipped jar.
- `guava` `compile` is correct: `Throwables.getStackTraceAsString` is called at 6 runtime sites, so it is not merely the `@VisibleForTesting` annotation.

## Two corrections to the issue text

Both are mine and both would have let a reviewer sign off on a check that cannot fail. I have corrected #46.

1. `unzip -l target/*.jar | grep -c 'org/junit\|org/hamcrest'` returns 0 before *and* after. Shade leaves both `junkEmailMover-1.0-SNAPSHOT.jar` and `original-junkEmailMover-1.0-SNAPSHOT.jar` in `target/`, and `unzip -l <archive> <name>` treats the second path as an in-archive filename filter, so it lists nothing. Naming the jar explicitly returns 398 on that same unfixed build.
2. A bare `java -jar` does not print the argument-count error. `EmailHandler.main` treats `args.length == 0` as "clear preferences" (`0 % 3 == 0`, so the error branch is skipped) and exits 0. Reaching the error needs an argument count that is neither 0 nor 1 mod 3, such as 2.

## Follow-up found, deliberately not in this diff

`dependency:analyze` reports `jakarta.mail:jakarta.mail-api:2.1.5` and `jakarta.activation:jakarta.activation-api:2.1.4` as used-but-undeclared: `src/main` imports `jakarta.mail.*` directly while receiving those artifacts only transitively through `angus-mail`. A real hygiene gap, but a different concern from scoping, so it gets its own issue rather than widening this one.
