### PR TITLE
chore: point CI trigger and README at renamed main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ mocks, so a dependency upgrade that changes protocol behaviour fails the build r
 
 CI runs that command once per Java version in the table above. The legs report as `test (Java 8)`,
 `test (Java 11)` and so on, and a separate job named `build` depends on them and fails unless every
-leg passed. `build` is the required status check on `master`, so do not rename it: a matrix leg
+leg passed. `build` is the required status check on `main`, so do not rename it: a matrix leg
 cannot take its place, and dropping it would leave the branch with a required check that matches
 no job at all.
 


### PR DESCRIPTION
The default branch was renamed from `master` to `main`.

The push trigger in `ci.yml` still filtered on `master`, so CI would no longer have run on the default branch after the rename. This points it at `main` and updates the matching README reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)