### PR TITLE
fix(deps): update Guava to 33.7.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.6.0-jre</version>
+            <version>33.7.1-jre</version>
         </dependency>
 
         <!-- Real in-process IMAP and SMTP servers, so the tests drive the actual


### PR DESCRIPTION
## Summary

- update Guava from 33.6.0-jre to 33.7.1-jre
- supersede #51's known-defective 33.7.0-jre target
- retain the existing dependency closure and application behavior

Guava 33.7.0 incorrectly marked its jar as multi-release without shipping versioned entries, which can break Java 9/10 compilation. Guava 33.7.1 removes that manifest entry. It was published on 2026-08-18 and is beyond the repository's seven-day release-age gate.

## Validation

- `mvn -B verify` in `maven:3.9.11-eclipse-temurin-25`: 26 tests passed, 0 failed/errors/skipped; JaCoCo gate passed
- independent exact-diff review: passed with no security or logic findings
- Guava 33.7.1 artifact/release delta and transitive closure reviewed

## Risk

Low. The diff is a one-line patch dependency update to the upstream fixed artifact. The repository's Guava use is covered by the existing behavioral suite.
